### PR TITLE
Update README.md with public Github clone link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ gem 'tailwindcss'
 or you can install the latest build:
 
 ```ruby
-gem 'tailwindcss', git: 'git@github.com:IcaliaLabs/tailwindcss-rails.git'
+gem 'tailwindcss', git: 'https://github.com/IcaliaLabs/tailwindcss-rails.git'
 ```
 
 Install the gem by running the bundle command:


### PR DESCRIPTION
HTTPS github link can be accessed publicly, ssh link requires keys and username/password.
See https://help.github.com/articles/which-remote-url-should-i-use/