### PR TITLE
Loosen railties dependency

### DIFF
--- a/tailwindcss.gemspec
+++ b/tailwindcss.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency("railties", ">= 4.1.0", "<= 6.0")
+  spec.add_dependency("railties", ">= 4.1.0", "<= 6.1")
 end


### PR DESCRIPTION
I couldn't find a way to bump rails to 6.0.1, this should fix that issue.